### PR TITLE
Richdown

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -18,15 +18,13 @@ function mergeConfig (config: MarkdocPluginConfig) {
   }
 }
 
-export default function (config: MarkdocPluginConfig) {
-  const mergedConfig = mergeConfig(config);
-
+function makePlugin (config: MarkdocPluginConfig, ls: LanguageSupport) {
   return ViewPlugin.fromClass(RichEditPlugin, {
     decorations: v => v.decorations,
     provide: v => [
       renderBlock(config?.markdoc),
       syntaxHighlighting(highlightStyle),
-      markdown(mergedConfig)
+      ls
     ],
     eventHandlers: {
       mousedown({ target }, view) {
@@ -35,4 +33,10 @@ export default function (config: MarkdocPluginConfig) {
       }
     }
   });
+}
+
+export default function (config: MarkdocPluginConfig) {
+  const mergedConfig = mergeConfig(config);
+
+  return makePlugin(config, markdown(mergedConfig));
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,14 +13,14 @@ export type MarkdocPluginConfig = { lezer?: any, markdoc: Config };
 
 export default function (config: MarkdocPluginConfig) {
   const mergedConfig = {
-    ...config.lezer ?? [],
-    extensions: [tagParser, ...config.lezer?.extensions ?? []]
+    ...config?.lezer ?? [],
+    extensions: [tagParser, ...config?.lezer?.extensions ?? []]
   };
 
   return ViewPlugin.fromClass(RichEditPlugin, {
     decorations: v => v.decorations,
     provide: v => [
-      renderBlock(config.markdoc),
+      renderBlock(config?.markdoc),
       syntaxHighlighting(highlightStyle),
       markdown(mergedConfig)
     ],

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { ViewPlugin } from '@codemirror/view';
-import { syntaxHighlighting } from '@codemirror/language';
+import { syntaxHighlighting, LanguageSupport } from '@codemirror/language';
 import { markdown } from '@codemirror/lang-markdown';
 
 import tagParser from './tagParser';
@@ -10,6 +10,16 @@ import renderBlock from './renderBlock';
 import type { Config } from '@markdoc/markdoc';
 
 export type MarkdocPluginConfig = { lezer?: any, markdoc: Config };
+
+export
+function richdown (config: MarkdocPluginConfig) {
+  const mergedConfig = mergeConfig(config);
+  const plugin = makePlugin(config);
+  const ls = markdown(mergedConfig);
+  ls.language.name = 'richdown';
+
+  return new LanguageSupport(ls, plugin);
+}
 
 function mergeConfig (config: MarkdocPluginConfig) {
   return {
@@ -24,7 +34,7 @@ function makePlugin (config: MarkdocPluginConfig, ls: LanguageSupport) {
     provide: v => [
       renderBlock(config?.markdoc),
       syntaxHighlighting(highlightStyle),
-      ls
+      ...(ls ? [ls] : [])
     ],
     eventHandlers: {
       mousedown({ target }, view) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,11 +11,15 @@ import type { Config } from '@markdoc/markdoc';
 
 export type MarkdocPluginConfig = { lezer?: any, markdoc: Config };
 
-export default function (config: MarkdocPluginConfig) {
-  const mergedConfig = {
+function mergeConfig (config: MarkdocPluginConfig) {
+  return {
     ...config?.lezer ?? [],
     extensions: [tagParser, ...config?.lezer?.extensions ?? []]
-  };
+  }
+}
+
+export default function (config: MarkdocPluginConfig) {
+  const mergedConfig = mergeConfig(config);
 
   return ViewPlugin.fromClass(RichEditPlugin, {
     decorations: v => v.decorations,


### PR DESCRIPTION
## What

Add a function that exports a `LanguageSupport` extension instead of a `ViewPlugin`. This is similar to CodeMirror language extensions, eg [lang-javascript](https://github.com/codemirror/lang-javascript) has a `javascript` function that exports a `LanguageSupport`.

The returned language is called "richdown", to make it unique from CodeMirror's "markdown". Seems better than "richdoc", which might be confused with RTF and [RichDoc](https://richdoc.sourceforge.net/).

## Why

This makes is easier to use this extension alongside other CodeMirror language extensions, when the extensions in general can be dynamically changed.

For example, the default export is adding markdown as an extension but I already have a mechanism for controlling which language extension is used.